### PR TITLE
Show all registered ui components in menu

### DIFF
--- a/app/ui/bakers_assistant/behaviors/com.bakersast.uistacks.card.livecodescript
+++ b/app/ui/bakers_assistant/behaviors/com.bakersast.uistacks.card.livecodescript
@@ -61,13 +61,28 @@ end _resizePreview
 private command PopulateUITypesMenu
   local tMenu
 
-  put "UI" & cr & "Templates" into tMenu
+  local tRegisteredComponents
+  put levureAppGet("registered components") into tRegisteredComponents
+  repeat for each key tKey in tRegisteredComponents["ui"]
+    if tKey is among the items of "ui,templates" then
+      next repeat
+    else
+      repeat with i = 1 to the number of words in tKey
+        put toUpper(codepoint 1 of word i of tKey) \
+          into codepoint 1 of word i of tKey
+      end repeat
+    end if
+    put tKey & cr after tMenu
+  end repeat
 
-  if levureAppHasProperty("embeddable views") then
-    put cr & "Embeddable Views" after tMenu
+  if tMenu is not empty then
+    sort lines of tMenu
+    put "-" & cr after tMenu
   end if
 
-  put cr & "Open Stacks" after tMenu
+  put "UI" & cr & "Templates" & cr & "-" & cr before tMenu
+
+  put "Open Stacks" after tMenu
 
   set the text of button "UIType" to tMenu
 end PopulateUITypesMenu


### PR DESCRIPTION
This patch updates the `PopulateUITypesMenu` menu to list all registered ui
components rather than just special casing an `Embeddable Views` item. To
provide a consistency to the menu the first two items are always `UI` and
`Templates` and the last item is always `Open Stacks`. Other registered
component stacks are listed in the middle section sorted by registered
component name.

<img width="209" alt="Screen Shot 2021-03-05 at 12 22 36 pm" src="https://user-images.githubusercontent.com/351144/110053416-7c1cab80-7dad-11eb-9a3f-e14db742d560.png">

Closes #8 